### PR TITLE
Fix short address decoding

### DIFF
--- a/contracts/RLP.sol
+++ b/contracts/RLP.sol
@@ -314,13 +314,11 @@ function toBytes32(RLPItem memory self) internal pure returns (bytes32 data, boo
 function toAddress(RLPItem memory self) internal pure returns (address data, bool valid) {
     if (!isData(self))
         return;
-    (uint256 rStartPos, uint256 len) = _decode(self);
-    if (len != 20)
+    (, uint256 len) = _decode(self);
+    if (len > 20)
         return;
-    assembly {
-        data := div(mload(rStartPos), exp(256, 12))
-    }
-    return (data, true);
+    (uint256 data, bool validUint) = toUint(self);
+    return (address(data), validUint);
 }
 
 // Get the payload offset.


### PR DESCRIPTION
Example addresses:
```
0x0014F55A50b281EFD12294f0Cda821Bd8171e920
0x0000000000000000000000000000000000000000
```